### PR TITLE
Don't export the modules in the public API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lz4"
 license = "MIT"
-version = "1.7.129"
+version = "1.7.130"
 authors = [ "Artem V. Navrotskiy <bozaro@buzzsoft.ru>" ]
 build = "src/build.rs"
 description = "Rust LZ4 bindings library."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-pub mod liblz4;
-pub mod decoder;
-pub mod encoder;
+mod liblz4;
+mod decoder;
+mod encoder;
 
 pub use decoder::Decoder;
 pub use encoder::Encoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod liblz4;
+pub mod liblz4;
 mod decoder;
 mod encoder;
 


### PR DESCRIPTION
This makes the docs nicer to understand and easier to look at.  You should do a
`cargo publish` as well, for the description typo to be fixed on crates.io.