### PR TITLE
Fix incorrect break that could cause reading after a frame ends

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -66,7 +66,7 @@ impl<R: Read> Read for Decoder<R> {
 				dst_offset += dst_size as usize;
 				if len == 0 {
 					self.eof = true;
-					break;
+					return Ok(dst_offset);
 				}
 			}
 		}


### PR DESCRIPTION
The break only exits the inner loop.  After setting eof, you should definitely return the data you have instead of reading more.  This bug would cause it to continue reading, even after a frame ends.  This would normally not cause a problem, if the stream ends after the frame, or if the reader knows exactly how much data to read.

However, this does cause a problem when decoding multiple lz4 frames on a network connection.  In that case, you would definitely want to return the data you read and read no more.