### PR TITLE
Don't try to fill up the entire buffer on a read.

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -41,12 +41,12 @@ impl<R: Read> Decoder<R> {
 impl<R: Read> Read for Decoder<R> {
 	fn read(&mut self, buf: &mut [u8]) -> Result<usize>
 	{
-		if self.eof
+		if self.eof || buf.len() == 0
 		{
 			return Ok(0);
 		}
 		let mut dst_offset: usize = 0;
-		while dst_offset < buf.len()
+		while dst_offset == 0
 		{
 			if self.pos >= self.len
 			{


### PR DESCRIPTION
An LZ4 frame is designed so that partial blocks can be "flushed" by
the encoder at any time.  A frame can be a long term stream sent over
a network connection.  The decoder needs to be sure that it only calls
the underlying read once at a time, when necessary, and be able to
return partially filled buffers.  This allows the caller to respond
to flushed data without the decoder blocking on a network read.