### PR TITLE
Fix conflicting import on Rust nightly

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,11 +1,8 @@
-extern crate libc;
-
 use std::io::Read;
 use std::io::Result;
 use std::ptr;
 use super::liblz4::*;
-
-use self::libc::size_t;
+use liblz4::libc::size_t;
 
 const BUFFER_SIZE: usize = 32 * 1024;
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,12 +1,9 @@
-extern crate libc;
-
 use std::io::Write;
 use std::io::Result;
 use std::cmp;
 use std::ptr;
 use super::liblz4::*;
-
-use self::libc::size_t;
+use liblz4::libc::size_t;
 
 struct EncoderContext {
 	c: LZ4FCompressionContext,


### PR DESCRIPTION
Importing libc crate in decoder.rs and encoder.rs conflict with the import in liblz4. I propose to use the import from liblz4 in decoder.rs and encoder.rs.