### PR TITLE
Import libc crate in libc.rs to fix warnings on rust-nightly

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,7 +1,7 @@
 use std::io::{Error, ErrorKind, Read, Result};
 use std::ptr;
 use super::liblz4::*;
-use liblz4::libc::size_t;
+use libc::size_t;
 
 const BUFFER_SIZE: usize = 32 * 1024;
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -3,7 +3,7 @@ use std::io::Result;
 use std::cmp;
 use std::ptr;
 use super::liblz4::*;
-use liblz4::libc::size_t;
+use libc::size_t;
 
 struct EncoderContext {
 	c: LZ4FCompressionContext,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate libc;
+
 pub mod liblz4;
 mod decoder;
 mod encoder;

--- a/src/liblz4.rs
+++ b/src/liblz4.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::io::Error;
@@ -7,7 +5,7 @@ use std::io::ErrorKind;
 use std::str;
 use std::ffi::CStr;
 
-use self::libc::{
+use libc::{
 	c_void,
 	c_char,
 	c_uint,


### PR DESCRIPTION
Rust Nightly now considers extern crates to be a private item and throws a warning when they are imported from a place that they are no longer visible from. This fixes those warnings.
