### PR TITLE
Modified build script to *always* compile the C code with -O3 optimization.

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -1,10 +1,13 @@
 extern crate gcc;
 
 fn main() {
-	gcc::compile_library("liblz4.a", &[
-		"liblz4/lib/lz4.c",
-		"liblz4/lib/lz4frame.c",
-		"liblz4/lib/lz4hc.c",
-		"liblz4/lib/xxhash.c",
-	]);
+    let mut compiler = gcc::Config::new();
+    compiler
+        .file("liblz4/lib/lz4.c")
+        .file("liblz4/lib/lz4frame.c")
+        .file("liblz4/lib/lz4hc.c")
+        .file("liblz4/lib/xxhash.c")
+        // We always compile the C with optimization, because otherwise it is 20x slower.
+        .opt_level(3) ;
+    compiler.compile("liblz4.a");
 }


### PR DESCRIPTION
If the lz4 C library is built without optimization, it is extraordinarily slow. As it is unlikely that users will need to trace into the C code, it makes sens to always build it with optimization.