### PR TITLE
Make Encoder and Decoder Send

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -96,7 +96,7 @@ impl<R: Read> Read for Decoder<R> {
 
 impl DecoderContext {
     fn new() -> Result<DecoderContext> {
-        let mut context: LZ4FDecompressionContext = ptr::null_mut();
+        let mut context = LZ4FDecompressionContext(ptr::null_mut());
         try!(check_error(unsafe { LZ4F_createDecompressionContext(&mut context, LZ4F_VERSION) }));
         Ok(DecoderContext { c: context })
     }
@@ -276,5 +276,12 @@ mod test {
 
     fn random_stream<R: Rng>(rng: &mut R, size: usize) -> Vec<u8> {
         rand::sample(rng, 0x00..0xFF, size)
+    }
+
+    #[test]
+    fn test_decoder_send() {
+        fn check_send<S: Send>(_: &S) {}
+        let dec = Decoder::new(Cursor::new(Vec::new())).unwrap();
+        check_send(&dec);
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -170,7 +170,7 @@ impl<W: Write> Write for Encoder<W> {
 
 impl EncoderContext {
     fn new() -> Result<EncoderContext> {
-        let mut context: LZ4FCompressionContext = ptr::null_mut();
+        let mut context = LZ4FCompressionContext(ptr::null_mut());
         try!(check_error(unsafe { LZ4F_createCompressionContext(&mut context, LZ4F_VERSION) }));
         Ok(EncoderContext { c: context })
     }
@@ -208,5 +208,12 @@ mod test {
         encoder.write(&buffer).unwrap();
         let (_, result) = encoder.finish();
         result.unwrap();
+    }
+
+    #[test]
+    fn test_encoder_send() {
+        fn check_send<S: Send>(_: &S) {}
+        let enc = EncoderBuilder::new().build(Vec::new());
+        check_send(&enc);
     }
 }

--- a/src/liblz4.rs
+++ b/src/liblz4.rs
@@ -7,9 +7,15 @@ use std::ffi::CStr;
 
 use libc::{c_void, c_char, c_uint, size_t};
 
-pub type LZ4FCompressionContext = *mut c_void;
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct LZ4FCompressionContext(pub *mut c_void);
+unsafe impl Send for LZ4FCompressionContext {}
 
-pub type LZ4FDecompressionContext = *mut c_void;
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct LZ4FDecompressionContext(pub *mut c_void);
+unsafe impl Send for LZ4FDecompressionContext {}
 
 pub type LZ4FErrorCode = size_t;
 


### PR DESCRIPTION
LZ4F{Compression,Decompression}Context are raw pointers which make
Encoder and Decoder non-Send. However, given that those contexts are
uniquely owned by the Encoder/Decoder, it is safe to implement Send on
them, making Encoder/Decoder Send themselves.

It would have been better to use std::ptr::Unique but it is still unstable.