### PR TITLE
Split out separate sys package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /target/
 /*.lock
 *.rs.bk
+/lz4-sys/target/
+/lz4-sys/*.lock

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "liblz4"]
-	path = liblz4
+	path = lz4-sys/liblz4
 	url = https://github.com/Cyan4973/lz4.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "lz4"
 license = "MIT"
 version = "1.19.173"
 authors = [ "Artem V. Navrotskiy <bozaro@buzzsoft.ru>" ]
-build = "src/build.rs"
+build = "build.rs"
 description = "Rust LZ4 bindings library."
 repository = "https://github.com/bozaro/lz4-rs"
 documentation = "https://bozaro.github.io/lz4-rs/lz4/"
@@ -15,6 +15,7 @@ doc = false
 
 [dependencies]
 libc = "0.2.17"
+lz4-sys = { path = "lz4-sys", version = "1.19.173" }
 
 [dev-dependencies]
 rand = "0.3.14"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+extern crate skeptic;
+
+fn main() {
+    skeptic::generate_doc_tests(&["README.md"]);
+}

--- a/lz4-sys/Cargo.toml
+++ b/lz4-sys/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "lz4-sys"
+license = "MIT"
+links = "lz4"
+version = "1.19.173"
+authors = [ "Artem V. Navrotskiy <bozaro@buzzsoft.ru>" ]
+build = "build.rs"
+description = "Rust LZ4 sys package."
+repository = "https://github.com/bozaro/lz4-rs"
+
+[dependencies]
+libc = "0.2.17"
+
+[build-dependencies]
+gcc = "0.3.38"

--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -1,5 +1,4 @@
 extern crate gcc;
-extern crate skeptic;
 
 use std::env;
 
@@ -21,6 +20,4 @@ fn main() {
       _ => {}
     }
     compiler.compile("liblz4.a");
-
-    skeptic::generate_doc_tests(&["README.md"]);
 }

--- a/lz4-sys/src/lib.rs
+++ b/lz4-sys/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate libc;
+
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::io::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate libc;
 
-pub mod liblz4;
+extern crate lz4_sys as liblz4;
 
 mod decoder;
 mod encoder;


### PR DESCRIPTION
When you have an lz4 dependency in another linked C library you don't need the full wrapper, just a way to compile and link lz4. This commit splits this part out into a separate sys crate to create this
possiblity.