### PR TITLE
Remove gcc from deps of lz4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,4 @@ rand = "0.3.15"
 skeptic = "0.9.0"
 
 [build-dependencies]
-gcc = "0.3.49"
 skeptic = "0.9.0"


### PR DESCRIPTION
It doesn't seem to me the crate `lz4` uses `gcc` anywhere. `lz4-sys` still uses `gcc` so it doesn't really reduce its dependencies, though.