### PR TITLE
make write_end public

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -104,7 +104,7 @@ impl<W: Write> Encoder<W> {
         self.w.write_all(&self.buffer)
     }
 
-    fn write_end(&mut self) -> Result<()> {
+    pub fn write_end(&mut self) -> Result<()> {
         unsafe {
             let len = try!(check_error(LZ4F_compressEnd(self.c.c,
                                                         self.buffer.as_mut_ptr(),


### PR DESCRIPTION
Currently calling the encoder `finish` method from `drop` is tough because it takes `mut self`. However, it just calls `write_end` underneath, which is `&mut self` already. Making this public will allow easily calling it from `drop` if the user chooses.