### PR TITLE
bump deps; rephrase broken test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ test = false
 doc = false
 
 [dependencies]
-libc = "0.2.23"
+libc = "0.2.39"
 lz4-sys = { path = "lz4-sys", version = "1.8.0" }
 
 [dev-dependencies]
-rand = "0.3.15"
-skeptic = "0.9.0"
+rand = "0.4"
+skeptic = "0.13"
 
 [build-dependencies]
-skeptic = "0.9.0"
+skeptic = "0.13"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -291,7 +291,7 @@ mod test {
     }
 
     fn random_stream<R: Rng>(rng: &mut R, size: usize) -> Vec<u8> {
-        rand::sample(rng, 0x00..0xFF, size)
+        (0..size).map(|_| rng.gen()).collect()
     }
 
     #[test]


### PR DESCRIPTION
Update deps.

Most interesting is the update of `skeptic`, which pulls in new `bitflags`, requiring Rust 1.20 to build.

The update of `rand` deprecates `rand::sample`, as it's frequently used incorrectly. It's used incorrectly here. The method is always just returning exactly `(0..255)`, unshuffled. `gen_iter()` is also deprecated. Never happy, these `rand` people.

Tests are green.