### PR TITLE
Add LZ4_compress_default and LZ4_decompress_safe functions

### DIFF
--- a/lz4-sys/src/lib.rs
+++ b/lz4-sys/src/lib.rs
@@ -319,11 +319,31 @@ extern "C" {
                                  input_size: i32)
                                  -> i32;
 
+    // int LZ4_compress_default(const char* source,
+    //                          char* dest,
+    //                          int inputSize,
+    //                          int maxOutputSize)
+    pub fn LZ4_compress_default(source: *const u8,
+                                dest: *mut u8,
+                                input_size: i32,
+                                max_output_size: i32)
+                                -> i32;
+
     // int LZ4_freeStream(LZ4_stream_t* LZ4_streamPtr)
     pub fn LZ4_freeStream(LZ4_stream: *mut LZ4StreamEncode) -> i32;
 
     // LZ4_streamDecode_t* LZ4_createStreamDecode(void)
     pub fn LZ4_createStreamDecode() -> *mut LZ4StreamDecode;
+
+    // int LZ4_decompress_safe(const char* source,
+    //                         char* dest,
+    //                         int compressedSize,
+    //                         int maxDecompressedSize)
+    pub fn LZ4_decompress_safe(source: *const u8,
+                               dest: *mut u8,
+                               compressed_size: i32,
+                               max_decompressed_size: i32)
+                               -> i32;
 
     // int LZ4_decompress_safe_continue(LZ4_streamDecode_t* LZ4_streamDecode,
     //                                  const char* source,


### PR DESCRIPTION
Although the library exposes mostly LZ4F functionality, it's useful (especially as the
library is called lz4) to have access to (at least) two main function calls for LZ4
compression and decompression.

Usage may look like the following (using LZ4_decompress_safe):
```
    // Assume src as being &Vec<u8>
    let src_ptr = src.as_ptr();
    let compressed_size = src.len() as i32;
    let mut dst: Box<[u8]> = vec![0; max_decompressed_size].into_boxed_slice();

    unsafe {
        let decompressed_size = lz4_sys::LZ4_decompress_safe(
            src_ptr,
            dst.as_mut_ptr(),
            compressed_size,
            max_decompressed_size);
    }
```

Should provide a minimum for https://github.com/bozaro/lz4-rs/issues/25