### PR TITLE
Add lz4 block mode, add LZ4_decompress_safe and LZ4_compress_{HC,fast,default}

### DIFF
--- a/lz4-sys/src/lib.rs
+++ b/lz4-sys/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 extern crate libc;
 
-use libc::{c_void, c_char, c_uint, size_t};
+use libc::{c_void, c_char, c_uint, size_t, c_int};
 
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -91,6 +91,23 @@ pub struct LZ4StreamDecode(c_void);
 pub const LZ4F_VERSION: c_uint = 100;
 
 extern "C" {
+
+    // int LZ4_compress_default(const char* source, char* dest, int sourceSize, int maxDestSize);
+    #[allow(non_snake_case)]
+    pub fn LZ4_compress_default (source: *const c_char, dest: *mut c_char, sourceSize: i32, maxDestSize: i32) -> i32;
+
+    // int LZ4_compress_fast (const char* source, char* dest, int sourceSize, int maxDestSize, int acceleration);
+    #[allow(non_snake_case)]
+    pub fn LZ4_compress_fast (source: *const c_char, dest: *mut c_char, sourceSize: i32, maxDestSize: i32, acceleration: i32) -> i32;
+
+    // int LZ4_compress_HC (const char* src, char* dst, int srcSize, int dstCapacity, int compressionLevel);
+    #[allow(non_snake_case)]
+    pub fn LZ4_compress_HC (src: *const c_char, dst: *mut c_char, srcSize: i32, dstCapacity: i32, compressionLevel: i32) -> i32;
+
+    // int LZ4_decompress_safe (const char* source, char* dest, int compressedSize, int maxDecompressedSize);
+    #[allow(non_snake_case)]
+    pub fn LZ4_decompress_safe (source: *const c_char, dest: *mut c_char, compressedSize: i32, maxDecompressedSize: i32) -> i32;
+
     // unsigned    LZ4F_isError(LZ4F_errorCode_t code);
     pub fn LZ4F_isError(code: size_t) -> c_uint;
 

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -1,0 +1,101 @@
+//! Defines the compression mode used by lz4 compress
+
+use super::liblz4::*;
+use std::io::{Error, ErrorKind, Result};
+
+
+pub enum CompressionMode {
+    HIGHCOMPRESSION(i32),
+    FAST(i32),
+    DEFAULT,
+}
+
+pub fn compress(src: &[u8], mode: Option<CompressionMode>) -> Result<Vec<u8>> {
+
+    // 0 iff src too large
+    let compress_bound: i32 = unsafe { LZ4_compressBound(src.len() as i32) };
+
+    if src.len() > (i32::max_value() as usize) || compress_bound <= 0 {
+        return Err(Error::new(ErrorKind::InvalidInput, "Compression input too long."));
+    }
+
+    let mut compressed: Vec<u8> = vec![0; compress_bound as usize];
+
+    let dec_size = match mode {
+        Some(CompressionMode::HIGHCOMPRESSION(level)) => unsafe {
+            LZ4_compress_HC(src.as_ptr() as *const i8,
+                            compressed.as_mut_ptr() as *mut i8,
+                            src.len() as i32,
+                            compress_bound,
+                            level)
+        },
+        Some(CompressionMode::FAST(accel)) => unsafe {
+            LZ4_compress_fast(src.as_ptr() as *const i8,
+                              compressed.as_mut_ptr() as *mut i8,
+                              src.len() as i32,
+                              compress_bound,
+                              accel)
+        },
+        _ => unsafe {
+            LZ4_compress_default(src.as_ptr() as *const i8,
+                                 compressed.as_mut_ptr() as *mut i8,
+                                 src.len() as i32,
+                                 compress_bound)
+        }
+    };
+
+    if dec_size <= 0 {
+        return Err(Error::new(ErrorKind::Other, "Compression failed"));
+    }
+
+    compressed.truncate(dec_size as usize);
+    Ok(compressed)
+}
+
+pub fn decompress(mut src: &[u8], uncompressed_size: Option<i32>) -> Result<Vec<u8>> {
+    let size;
+
+    if let Some(s) = uncompressed_size {
+        size = s;
+    } else {
+        if src.len() < 4 {
+            return Err(Error::new(ErrorKind::InvalidInput, "Source buffer must at least contain size prefix."))
+
+        }
+        size = ((src[0] as i32) | (src[1] as i32) << 8 | (src[2] as i32) << 16 | (src[3] as i32) << 24);
+
+        src = &src[4..];
+    }
+
+    if size <= 0 {
+        return Err(Error::new(ErrorKind::InvalidInput,
+                              if uncompressed_size.is_some() {
+                                  "Size parameter must not be negative."
+                              } else {
+                                  "Parsed size prefix in buffer must not be negative."
+                              }));
+    }
+
+    if unsafe { LZ4_compressBound(size) } <= 0  {
+        return Err(Error::new(ErrorKind::InvalidInput, "Given size parameter is too big"))
+    }
+
+
+
+    let mut decompressed = vec![0u8; size as usize];
+    let dec_bytes = unsafe {
+        LZ4_decompress_safe(src.as_ptr() as *const i8,
+                            decompressed.as_mut_ptr() as *mut i8,
+                            src.len() as i32,
+                            size,
+        )
+    };
+
+    if dec_bytes < 0 {
+        return Err(Error::new(ErrorKind::InvalidData, "Decompression failed. Input invalid or too long?"))
+    }
+
+    decompressed.truncate(dec_bytes as usize);
+    Ok(decompressed)
+}
+

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -1,16 +1,47 @@
-//! Defines the compression mode used by lz4 compress
+//! This module provides access to the block mode functions of the lz4 C library.
+//! It somehow resembles the [Python-lz4](http://python-lz4.readthedocs.io/en/stable/lz4.block.html) api,
+//! but using Rust's Option type, the function parameters have been a little simplified.
+//! As does python-lz4, this module supports prepending the compressed buffer with a u32 value
+//! representing the size of the original, uncompressed data.
+//!
+//! # Examples
+//! ```
+//!
+//! use lz4::block::{compress,decompress};
+//!
+//! let v = vec![0u8; 1024];
+//!
+//! let comp_with_prefix = compress(&v, None, true).unwrap();
+//! let comp_wo_prefix = compress(&v, None, false).unwrap();
+//!
+//! assert_eq!(v, decompress(&comp_with_prefix, None).unwrap());
+//! assert_eq!(v, decompress(&comp_wo_prefix, Some(1024)).unwrap());
+//! ```
 
 use super::liblz4::*;
 use std::io::{Error, ErrorKind, Result};
 
-
+/// Represents the compression mode do be used.
 pub enum CompressionMode {
+    /// High compression with compression parameter
     HIGHCOMPRESSION(i32),
+    /// Fast compression with acceleration paramet
     FAST(i32),
+    /// Default compression
     DEFAULT,
 }
 
-pub fn compress(src: &[u8], mode: Option<CompressionMode>) -> Result<Vec<u8>> {
+/// Compresses the full src buffer using the specified CompressionMode, where None and Some(Default)
+/// are treated equally. If prepend_size is set, the source length will be prepended to the output
+/// buffer.
+///
+///
+/// # Errors
+/// Returns std::io::Error with ErrorKind::InvalidInput if the src buffer is too long.
+/// Returns std::io::Error with ErrorKind::Other if the compression failed inside the C library. If
+/// this happens, the C api was not able to provide more information about the cause.
+///
+pub fn compress(src: &[u8], mode: Option<CompressionMode>, prepend_size: bool) -> Result<Vec<u8>> {
 
     // 0 iff src too large
     let compress_bound: i32 = unsafe { LZ4_compressBound(src.len() as i32) };
@@ -19,39 +50,63 @@ pub fn compress(src: &[u8], mode: Option<CompressionMode>) -> Result<Vec<u8>> {
         return Err(Error::new(ErrorKind::InvalidInput, "Compression input too long."));
     }
 
-    let mut compressed: Vec<u8> = vec![0; compress_bound as usize];
+    let mut compressed: Vec<u8> = vec![0; (if prepend_size { compress_bound + 4 } else { compress_bound }) as usize];
 
-    let dec_size = match mode {
-        Some(CompressionMode::HIGHCOMPRESSION(level)) => unsafe {
-            LZ4_compress_HC(src.as_ptr() as *const i8,
-                            compressed.as_mut_ptr() as *mut i8,
-                            src.len() as i32,
-                            compress_bound,
-                            level)
-        },
-        Some(CompressionMode::FAST(accel)) => unsafe {
-            LZ4_compress_fast(src.as_ptr() as *const i8,
-                              compressed.as_mut_ptr() as *mut i8,
-                              src.len() as i32,
-                              compress_bound,
-                              accel)
-        },
-        _ => unsafe {
-            LZ4_compress_default(src.as_ptr() as *const i8,
-                                 compressed.as_mut_ptr() as *mut i8,
-                                 src.len() as i32,
-                                 compress_bound)
+    let dec_size;
+    {
+        let dst_buf: &mut [u8];
+        if prepend_size {
+            let size = src.len() as u32;
+            compressed[0] = size as u8;
+            compressed[1] = (size >> 8) as u8;
+            compressed[2] = (size >> 16) as u8;
+            compressed[3] = (size >> 24) as u8;
+            dst_buf = &mut compressed[4..];
+        } else {
+            dst_buf = &mut compressed;
         }
-    };
 
+        dec_size = match mode {
+            Some(CompressionMode::HIGHCOMPRESSION(level)) => unsafe {
+                LZ4_compress_HC(src.as_ptr() as *const i8,
+                                dst_buf.as_mut_ptr() as *mut i8,
+                                src.len() as i32,
+                                compress_bound,
+                                level)
+            },
+            Some(CompressionMode::FAST(accel)) => unsafe {
+                LZ4_compress_fast(src.as_ptr() as *const i8,
+                                  dst_buf.as_mut_ptr() as *mut i8,
+                                  src.len() as i32,
+                                  compress_bound,
+                                  accel)
+            },
+            _ => unsafe {
+                LZ4_compress_default(src.as_ptr() as *const i8,
+                                     dst_buf.as_mut_ptr() as *mut i8,
+                                     src.len() as i32,
+                                     compress_bound)
+            }
+        };
+    }
     if dec_size <= 0 {
         return Err(Error::new(ErrorKind::Other, "Compression failed"));
     }
 
-    compressed.truncate(dec_size as usize);
+    compressed.truncate(if prepend_size {dec_size + 4} else {dec_size} as usize);
     Ok(compressed)
 }
 
+/// Decompresses the src buffer. If uncompressed_size is None, the source length will be read from
+/// the start of the input buffer.
+///
+///
+/// # Errors
+/// Returns std::io::Error with ErrorKind::InvalidInput if the src buffer is too short, the
+/// provided (or parsed) uncompressed_size is to large or negative.
+/// Returns std::io::Error with ErrorKind::InvalidData if the decompression failed inside the C
+/// library. This is most likely due to malformed input.
+///
 pub fn decompress(mut src: &[u8], uncompressed_size: Option<i32>) -> Result<Vec<u8>> {
     let size;
 
@@ -59,8 +114,7 @@ pub fn decompress(mut src: &[u8], uncompressed_size: Option<i32>) -> Result<Vec<
         size = s;
     } else {
         if src.len() < 4 {
-            return Err(Error::new(ErrorKind::InvalidInput, "Source buffer must at least contain size prefix."))
-
+            return Err(Error::new(ErrorKind::InvalidInput, "Source buffer must at least contain size prefix."));
         }
         size = ((src[0] as i32) | (src[1] as i32) << 8 | (src[2] as i32) << 16 | (src[3] as i32) << 24);
 
@@ -76,10 +130,9 @@ pub fn decompress(mut src: &[u8], uncompressed_size: Option<i32>) -> Result<Vec<
                               }));
     }
 
-    if unsafe { LZ4_compressBound(size) } <= 0  {
-        return Err(Error::new(ErrorKind::InvalidInput, "Given size parameter is too big"))
+    if unsafe { LZ4_compressBound(size) } <= 0 {
+        return Err(Error::new(ErrorKind::InvalidInput, "Given size parameter is too big"));
     }
-
 
 
     let mut decompressed = vec![0u8; size as usize];
@@ -92,10 +145,89 @@ pub fn decompress(mut src: &[u8], uncompressed_size: Option<i32>) -> Result<Vec<
     };
 
     if dec_bytes < 0 {
-        return Err(Error::new(ErrorKind::InvalidData, "Decompression failed. Input invalid or too long?"))
+        return Err(Error::new(ErrorKind::InvalidData, "Decompression failed. Input invalid or too long?"));
     }
 
     decompressed.truncate(dec_bytes as usize);
     Ok(decompressed)
 }
 
+#[cfg(test)]
+mod test {
+    use block::{compress, decompress, CompressionMode};
+
+    #[test]
+    fn test_compression_without_prefix() {
+        let size = 65536;
+        let mut to_compress = Vec::with_capacity(size);
+        for i in 0..size {
+            to_compress.push(i as u8);
+        }
+        let mut v: Vec<Vec<u8>> = vec!();
+        for i in 1..100 {
+            v.push(compress(&to_compress, Some(CompressionMode::FAST(i)), false).unwrap());
+        }
+
+        // 12 is max high compression parameter
+        for i in 1..12 {
+            v.push(compress(&to_compress, Some(CompressionMode::HIGHCOMPRESSION(i)), false).unwrap());
+        }
+
+        v.push(compress(&to_compress, None, false).unwrap());
+
+        for val in v {
+            assert_eq!(decompress(&val, Some(to_compress.len() as i32)).unwrap(), to_compress);
+        }
+    }
+
+    #[test]
+    fn test_compression_with_prefix() {
+        let size = 65536;
+        let mut to_compress = Vec::with_capacity(size);
+        for i in 0..size {
+            to_compress.push(i as u8);
+        }
+        let mut v: Vec<Vec<u8>> = vec!();
+        for i in 1..100 {
+            v.push(compress(&to_compress, Some(CompressionMode::FAST(i)), true).unwrap());
+        }
+
+        // 12 is max high compression parameter
+        for i in 1..12 {
+            v.push(compress(&to_compress, Some(CompressionMode::HIGHCOMPRESSION(i)), true).unwrap());
+        }
+
+        v.push(compress(&to_compress, None, true).unwrap());
+
+        for val in v {
+            assert_eq!(decompress(&val, None).unwrap(), to_compress);
+        }
+    }
+
+
+    #[test]
+    fn test_decompression_with_prefix() {
+        let compressed: [u8; 250] = [0, 188, 0, 0, 255, 32, 116, 104, 105, 115, 32, 105, 115, 32, 97,
+            32, 116, 101, 115, 116, 32, 115, 116, 114, 105, 110, 103, 32, 99, 111, 109, 112, 114,
+            101, 115, 115, 101, 100, 32, 98, 121, 32, 112, 121, 116, 104, 111, 110, 45, 108, 122,
+            52, 32, 47, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 117, 80, 45, 108, 122, 52, 32];
+
+        let mut reference: String = String::new();
+        for _ in 0..1024 {
+            reference += "this is a test string compressed by python-lz4 ";
+        }
+
+        assert_eq!(decompress(&compressed, None).unwrap(), reference.as_bytes())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub mod liblz4;
 mod decoder;
 mod encoder;
 
+pub mod block;
+
 pub use decoder::Decoder;
 pub use encoder::Encoder;
 pub use encoder::EncoderBuilder;


### PR DESCRIPTION
This PR adds the lz4 block mode and the necessary compress and decompress bindings for C lz4.
Block mode is implemented to be compatible with lz4 libraries for other languages, such as Python.
Added module and functions are documented.

Also, closes #25
This extends #28, which does not need to be merged.