### PR TITLE
Switch to docmatic for testing README.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ license = "MIT"
 version = "1.23.1"
 readme = "README.md"
 authors = [ "Jens Heyens <jens.heyens@ewetel.net>", "Artem V. Navrotskiy <bozaro@buzzsoft.ru>" ]
-build = "build.rs"
 description = "Rust LZ4 bindings library."
 repository = "https://github.com/bozaro/lz4-rs"
 documentation = "https://bozaro.github.io/lz4-rs/lz4/"
@@ -20,7 +19,4 @@ lz4-sys = { path = "lz4-sys", version = "1.8.3" }
 
 [dev-dependencies]
 rand = "0.6.1"
-skeptic = "0.13.3"
-
-[build-dependencies]
-skeptic = "0.13.3"
+docmatic = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,0 @@
-extern crate skeptic;
-
-fn main() {
-    skeptic::generate_doc_tests(&["README.md"]);
-}

--- a/tests/docmatic.rs
+++ b/tests/docmatic.rs
@@ -1,0 +1,6 @@
+extern crate docmatic;
+
+#[test]
+fn test_readme() {
+    docmatic::assert_file("README.md");
+}

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,1 +1,0 @@
-include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
Similar to skeptic, but it does not add itself as a build dependency, which means that all downstream users of LZ4 don't need to build skeptic (and all its dependencies).

See https://github.com/budziq/rust-skeptic/issues/60.