### PR TITLE
lz4-sys: link against system liblz4 if possible

### DIFF
--- a/lz4-sys/Cargo.toml
+++ b/lz4-sys/Cargo.toml
@@ -13,3 +13,4 @@ libc = "0.2.44"
 
 [build-dependencies]
 cc = "1.0.25"
+pkg-config = "0.3.14"

--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -3,6 +3,12 @@ extern crate cc;
 use std::env;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=LZ4_API_STATIC");
+    let want_static = env::var("LZ4_API_STATIC").is_ok();
+    if !want_static && pkg_config::probe_library("liblz4").is_ok() {
+        return;
+    }
+
     let mut compiler = cc::Build::new();
     compiler
         .file("liblz4/lib/lz4.c")


### PR DESCRIPTION
This brings lz4-sys in line with lzma-sys and libz-sys.