### PR TITLE
Allow delegating all linking

### DIFF
--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -5,6 +5,14 @@ use std::error::Error;
 use std::path::PathBuf;
 
 fn main() {
+    let k = "LZ4_SYS_DELEGATE_LINKING";
+
+    println!("cargo:rerun-if-env-changed={}", k);
+
+    if env::var(k).is_ok() {
+        return;
+    }
+
     match run() {
         Ok(()) => (),
         Err(err) => {


### PR DESCRIPTION
This is helpful when an external build system (e.g. Buck) is taking care
of linking liblz4, and we don't want the Rust compiler to emit any
linking arguments.

To do so, this adds a flag to just bail out of the build script and not
build any native crate if LZ4_SYS_DELEGATE_LINKING is set in the
environment.