### PR TITLE
Add LZ4_ prefix to lz4_sys's internal XXHASH symbols

### DIFF
--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -21,6 +21,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         .file("liblz4/lib/lz4frame.c")
         .file("liblz4/lib/lz4hc.c")
         .file("liblz4/lib/xxhash.c")
+        .define("XXH_NAMESPACE", "LZ4_")
         // We always compile the C with optimization, because otherwise it is 20x slower.
         .opt_level(3);
     match env::var("TARGET")


### PR DESCRIPTION
For users of lz4, this prevents possible linking collisions with other instances of XXHASH from other libraries in the executable.