### PR TITLE
Add support for dictionary compression.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod block;
 pub use decoder::Decoder;
 pub use encoder::Encoder;
 pub use encoder::EncoderBuilder;
+pub use encoder::EncoderDictionary;
 pub use liblz4::version;
 pub use liblz4::BlockMode;
 pub use liblz4::BlockSize;

--- a/src/liblz4.rs
+++ b/src/liblz4.rs
@@ -8,7 +8,13 @@ use std::str;
 pub use lz4_sys::*;
 
 #[derive(Debug)]
-pub struct LZ4Error(String);
+pub struct LZ4Error(pub String);
+
+impl LZ4Error {
+    pub fn new(reason: String) -> LZ4Error {
+        LZ4Error(reason)
+    }
+}
 
 impl Display for LZ4Error {
     fn fmt(&self, f: &mut Formatter) -> Result<(), ::std::fmt::Error> {


### PR DESCRIPTION
LZ4 supports using a dictionary when processing data, which can make
a big difference on small messages/files. This change exposes the
relevant functions in lz4-sys, and extends Encoder and Decoder to
support using dictionaries.